### PR TITLE
Shadow map scene fitting and shadow map reuse

### DIFF
--- a/external/NiceMath.h
+++ b/external/NiceMath.h
@@ -1606,6 +1606,22 @@ namespace nm {
              scaleVec       = nm::float3(1.0f);
          }
 
+         // for now only handling scaling multiplication
+         //Transform operator*(nm::Transform const& p_rhs)
+         //{
+         //   Transform temp;
+         //   //temp.SetScale(scale * p_rhs.scale);
+         //   //temp.SetRotation(p_rhs.rotate);
+         //   //temp.SetTranslate(p_rhs.translate);
+         //   temp = p_rhs;
+         //   return temp;
+         //}
+
+         nm::float4x4 GetTranslate()   const { return translate; }
+         nm::float4x4 GetRotate()      const { return rotate; }
+         nm::float4x4 GetScale()       const { return scale; }
+         nm::float4x4 GetTransform()   const { return transform; }
+
          nm::float4x4 GetTranslate() { return translate; }
          nm::float4x4 GetRotate() { return rotate; }
          nm::float4x4 GetScale() { return scale; }
@@ -1636,6 +1652,56 @@ namespace nm {
              transform = scale * rotate * translate;
          }
 
+         void SetRotation(float p_roll, float p_pitch, float p_yaw)
+         {
+             rotate = nm::float4x4::identity();
+             nm::float4x4 yawMat = nm::float4x4::identity();
+             nm::float4x4 pitchMat = nm::float4x4::identity();
+             nm::float4x4 rollMat = nm::float4x4::identity();
+
+             float su = sin(p_roll);
+             float cu = cos(p_roll);
+             float sv = sin(p_pitch);
+             float cv = cos(p_pitch);
+             float sw = sin(p_yaw);
+             float cw = cos(p_yaw);
+
+             //ensure order for multiplixation - (roll * yaw) * pitch 
+
+             if(p_roll != 0.0f)
+             {
+                rollMat = nm::float4x4::from_rows(  nm::float4(cos(p_roll),     sin(p_roll),    0.0f,           0.0f),
+                                                    nm::float4(-sin(p_roll),    cos(p_roll),    0.0f,           0.0f),
+                                                    nm::float4(0.0f,            0.0f,           1.0f,           0.0f),
+                                                    nm::float4(0.0f,            0.0f,           0.0f,           1.0f));
+
+                rotate = rotate * rollMat;
+             }
+
+             if(p_yaw != 0.0f)
+             {
+                yawMat = nm::float4x4::from_rows(   nm::float4(cos(p_yaw),      0.0f,           -sin(p_yaw),   0.0f),
+                                                    nm::float4(0.0f,            1.0f,           0.0f,          0.0f),
+                                                    nm::float4(sin(p_yaw),      0.0f,           cos(p_yaw),    0.0f),
+                                                    nm::float4(0.0f,            0.0f,           0.0f,          1.0f));
+
+                rotate = rotate * yawMat;
+             }
+
+             if(p_pitch != 0.0f)
+             {
+                pitchMat = nm::float4x4::from_rows( nm::float4(1.0f,            0.0f,          0.0f,           0.0f),
+                                                    nm::float4(0.0f,            cos(p_pitch),  sin(p_pitch),   0.0f),
+                                                    nm::float4(0.0f,            -sin(p_pitch), cos(p_pitch),   0.0f),
+                                                    nm::float4(0.0f,            0.0f,          0.0f,           1.0f));
+
+                rotate = rotate * pitchMat;
+             }
+
+             Decompose2Rotation(rotate, rotateVec);
+             transform = scale * rotate * translate;
+         }
+
          void SetScale(nm::float4x4 p_scale)
          {
              scale = p_scale;
@@ -1652,5 +1718,21 @@ namespace nm {
              transform.column[3][2] = translate.column[3][2];
              transform.column[3][3] = translate.column[3][3];
          }
+
+         void SetTranslate(nm::float4 p_translate)
+         {
+             translateVec = p_translate.xyz();
+
+             translate.column[3][0] = p_translate[0];
+             translate.column[3][1] = p_translate[1];
+             translate.column[3][2] = p_translate[2];
+             translate.column[3][3] = p_translate[3];
+          
+             transform.column[3][0] = p_translate[0];
+             transform.column[3][1] = p_translate[1];
+             transform.column[3][2] = p_translate[2];
+             transform.column[3][3] = p_translate[3];
+         }
+
      };
 }

--- a/src/Pass.h
+++ b/src/Pass.h
@@ -26,6 +26,7 @@ public:
 		nm::float2					screenRes;
 		bool						leftMouseDown;
 		bool						rightMouseDown;
+		CSceneGraph*				sceneGraph;
 	};
 
 	CPass(CVulkanRHI* p_core)

--- a/src/RasterRender.h
+++ b/src/RasterRender.h
@@ -81,13 +81,12 @@ private:
 	CToneMapPass*						m_toneMapPass;
 	CUIPass*							m_uiPass;
 	
-
 	bool InitCamera();
 	bool CreateSyncPremitives();																															
 	void DestroySyncPremitives();
 	bool CreatePasses();
 
-	void UpdateCamera(float p_delta);																																
+	bool UpdateCamera(float p_delta);																																
 	bool DoReadBackObjPickerBuffer(uint32_t p_swapchainIndex, CVulkanRHI::CommandBuffer& p_cmdBfr);
 	bool RenderForward();
 	bool RenderDeferred();

--- a/src/ShadowPass.cpp
+++ b/src/ShadowPass.cpp
@@ -4,6 +4,7 @@ CStaticShadowPrepass::CStaticShadowPrepass(CVulkanRHI* p_rhi)
 	: CPass(p_rhi)
 {
 	m_frameBuffer.resize(1);
+	m_bReuseShadowMap = false;
 }
 
 CStaticShadowPrepass::~CStaticShadowPrepass()
@@ -12,7 +13,7 @@ CStaticShadowPrepass::~CStaticShadowPrepass()
 
 bool CStaticShadowPrepass::CreateRenderpass(RenderData* p_renderData)
 {
-	CVulkanRHI::Image renderTarget			= p_renderData->fixedAssets->GetRenderTargets()->GetTexture(CRenderTargets::rt_LightDepth);
+	CVulkanRHI::Image renderTarget			= p_renderData->fixedAssets->GetRenderTargets()->GetTexture(CRenderTargets::rt_DirectionalShadowDepth);
 	CVulkanRHI::Renderpass* renderpass		= &m_pipeline.renderpassData; 
 
 	renderpass->AttachDepth(renderTarget.format, VK_ATTACHMENT_LOAD_OP_CLEAR, VK_ATTACHMENT_STORE_OP_STORE,	VK_IMAGE_LAYOUT_UNDEFINED,	VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,	VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
@@ -88,8 +89,11 @@ bool CStaticShadowPrepass::CreatePipeline(CVulkanCore::Pipeline p_Pipeline)
 	return true;
 }
 
-bool CStaticShadowPrepass::Update(UpdateData*)
+bool CStaticShadowPrepass::Update(UpdateData* p_updateData)
 {
+	// we are choosig to reuse the shadow map if the scene graph has not gone through any changes 
+	m_bReuseShadowMap = (p_updateData->sceneGraph->GetSceneStatus() == CSceneGraph::SceneStatus::ss_NoChange) ? true : false;
+	
 	return true;
 }
 

--- a/src/ShadowPass.h
+++ b/src/ShadowPass.h
@@ -16,4 +16,9 @@ public:
 	virtual void Destroy() override;
 
 	virtual void GetVertexBindingInUse(CVulkanCore::VertexBinding&)override;
+
+	bool ReuseShadowMap() { return m_bReuseShadowMap; }
+
+private:
+	bool m_bReuseShadowMap;
 };

--- a/src/core/Asset.h
+++ b/src/core/Asset.h
@@ -266,7 +266,7 @@ public:
 		, rt_Albedo					= 3
 		, rt_SSAO					= 4
 		, rt_SSAOBlur				= 5
-		, rt_LightDepth				= 6
+		, rt_DirectionalShadowDepth	= 6
 		, rt_PrimaryColor			= 7
 		, rt_DeferredRoughMetal		= 8
 		, rt_max

--- a/src/core/AssetLoader.h
+++ b/src/core/AssetLoader.h
@@ -2,6 +2,7 @@
 
 #include <iostream>
 #include <vector>
+#include <cmath>
 
 #include "external/NiceMath.h"
 
@@ -80,6 +81,19 @@ struct BBox
 	nm::float3					bbMax;
 	nm::float3					bBox[8];
 	BBox(Type p_type = Null, Origin p_origin = Auto);
+	
+	BBox operator* (nm::Transform const& p_transform);
+	bool operator==(const BBox& other);
+	
+	void Merge(const BBox&);
+	void Reset(Type p_type = Null, Origin p_origin = Auto);
+
+	float GetDepth() const;		// along Z
+	float GetHeight() const;	// along Y
+	float GetWidth() const;		// along X
+
+private:
+	void CalculateCorners();
 };
 
 struct SubMesh

--- a/src/core/Camera.h
+++ b/src/core/Camera.h
@@ -46,6 +46,8 @@ public:
     const nm::float3 GetLookAt() const { return m_lookAt; }
 
 protected:
+    bool                            m_bInverted;
+    const nm::float3                c_up = nm::float3(0.0f, -1.0f * (m_bInverted ? -1.0f : 1.0f), 0.0f);
     float                           m_dist;
     float                           m_zNear;
     float                           m_zFar;
@@ -126,12 +128,12 @@ public:
         virtual void Pure() override {};
     };
 
-    COrthoCamera(std::string p_entityName) : CCamera(p_entityName) {}
+    COrthoCamera(std::string p_entityName);
     ~COrthoCamera() {}
 
     virtual bool Init(InitData* p_initData) override;
     virtual void Update(UpdateData p_data) override;
 
 private:
-    nm::float4 m_lrbt;  // left, right, bottom, top
+    nm::float4                  m_lrbt;  // left, right, bottom, top
 };


### PR DESCRIPTION
Provided perfect fitting between scene's bounding box and directional shadow's frustrum. Also optimised pipeline by reusing the shadow map if the scene has not been changed. Shadow map is only generated if the meshes in the scene have been moved.